### PR TITLE
feat: add CVM lifecycle methods for v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,7 +1102,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "phala-tee-deploy-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "dotenv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "phala-tee-deploy-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
-description = "A secure TEE deployment library for managing Docker containers in trusted environments"
+description = "Rust client for deploying and managing Docker containers on Phala TEE Cloud (dstack)"
 license = "MIT"
+repository = "https://github.com/tangle-network/phala-tee-deploy-rs"
+documentation = "https://docs.rs/phala-tee-deploy-rs"
+keywords = ["tee", "phala", "confidential-computing", "docker", "deployment"]
+categories = ["api-bindings", "cryptography"]
 
 [dependencies]
 tokio = { version = "1.36", features = ["full"] }
@@ -20,16 +24,11 @@ dotenv = "0.15.0"
 serde_yaml = "0.9"
 
 [dev-dependencies]
-dotenv = "0.15.0"
 tokio-test = "0.4"
 wiremock = "0.5"
 
 [package.metadata.docs.rs]
-# Enable all features when building docs
 all-features = true
-# Add custom CSS
 rustdoc-args = ["--cfg", "docsrs"]
-# Specify the default target
 default-target = "x86_64-unknown-linux-gnu"
-# Configure which platforms are included in the build matrix
-targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
+targets = ["x86_64-unknown-linux-gnu"]

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -82,8 +82,6 @@ impl Encryptor {
         shared_secret_bytes: [u8; 32],
         iv: [u8; 12],
     ) -> Result<String, Error> {
-        println!("Encrypting environment variables with fixed components");
-
         // Decode remote public key (remove 0x prefix if present)
         let clean_pubkey = remote_pubkey_hex.trim_start_matches("0x");
         let remote_pubkey_bytes = hex::decode(clean_pubkey)
@@ -138,8 +136,6 @@ impl Encryptor {
         ephemeral_secret: EphemeralSecret,
         iv: [u8; 12],
     ) -> Result<String, Error> {
-        println!("Encrypting environment variables");
-
         // Decode remote public key (remove 0x prefix if present)
         let clean_pubkey = remote_pubkey_hex.trim_start_matches("0x");
         let remote_pubkey_bytes = hex::decode(clean_pubkey)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
 //!         None,
 //!         None,
 //!         None,
+//!         None,
 //!     ).await?;
 //!
 //!     println!("Deployment successful: {:?}", result);
@@ -75,21 +76,22 @@
 //!         .build()?;
 //!
 //!     let teepods = deployer.discover_teepod().await?;
-//!     
+//!
 //!     // Create VM configuration
-//!     let vm_config = deployer.create_vm_config_from_string(
+//!     let vm_config = deployer.create_vm_config(
 //!         "version: '3'\nservices:\n  app:\n    image: nginx:alpine",
 //!         "secure-app",
 //!         None, None, None
 //!     )?;
-//!     
+//!
 //!     // Get encryption public key
-//!     let pubkey_response: PubkeyResponse = deployer.get_pubkey_for_config(&vm_config).await?;
+//!     let vm_config_value = serde_json::to_value(&vm_config).unwrap();
+//!     let pubkey_response: PubkeyResponse = deployer.get_pubkey_for_config(&vm_config_value).await?;
 //!     let pubkey = pubkey_response.app_env_encrypt_pubkey;
 //!     let salt = pubkey_response.app_id_salt;
-//!     
+//!
 //!     // Return VM config and encryption keys (to be sent to user)
-//!     Ok((vm_config, pubkey, salt))
+//!     Ok((vm_config_value, pubkey, salt))
 //! }
 //!
 //! // USER: Encrypt sensitive data
@@ -119,7 +121,7 @@
 //!
 //!     // Deploy with encrypted environment variables
 //!     let deployment = deployer.deploy_with_encrypted_env(
-//!         vm_config, encrypted_env, pubkey
+//!         vm_config, encrypted_env, &pubkey, &salt
 //!     ).await?;
 //!     
 //!     println!("Deployed successfully: {}", deployment.id);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -25,14 +25,24 @@ fn create_test_config(api_url: String) -> DeploymentConfig {
 async fn test_successful_deployment_flow() {
     let mock_server = MockServer::start().await;
 
-    // Mock the pubkey endpoint with validation
+    // Mock the pubkey endpoint with a full PubkeyResponse body
     Mock::given(method("POST"))
         .and(path("/cvms/pubkey/from_cvm_configuration"))
         .and(header("Content-Type", "application/json"))
         .and(header("x-api-key", "test_api_key"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "app_env_encrypt_pubkey": format!("0x{}", hex::encode([1u8; 32])),
-            "app_id_salt": "test_salt"
+            "app_id": "app_1",
+            "app_id_salt": "test_salt",
+            "compose_manifest": { "name": "test", "features": [], "docker_compose_file": "" },
+            "disk_size": 10,
+            "encrypted_env": "",
+            "image": "test:latest",
+            "listed": false,
+            "memory": 1024,
+            "name": "test",
+            "teepod_id": 1,
+            "vcpu": 1
         })))
         .expect(1)
         .mount(&mock_server)
@@ -116,16 +126,33 @@ async fn test_get_available_teepods() {
         .and(header("Content-Type", "application/json"))
         .and(header("x-api-key", "test_api_key"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "capacity": { "max_disk": 100, "max_instances": 10, "max_memory": 65536, "max_vcpu": 16 },
+            "tier": "pro",
             "nodes": [
                 {
                     "teepod_id": 123,
+                    "listed": true,
+                    "name": "test-node",
+                    "remaining_cvm_slots": 5,
+                    "remaining_memory": 32768.0,
+                    "remaining_vcpu": 8.0,
+                    "resource_score": 0.8,
                     "images": [
                         {
                             "name": "test-image:latest",
-                            "tag": "latest"
+                            "bios": "bios.bin",
+                            "cmdline": "",
+                            "description": "test image",
+                            "hda": null,
+                            "initrd": "initrd.img",
+                            "is_dev": false,
+                            "kernel": "vmlinuz",
+                            "rootfs": "rootfs.img",
+                            "rootfs_hash": "abc123",
+                            "shared_ro": false,
+                            "version": [1, 0, 0]
                         }
-                    ],
-                    "status": "ready"
+                    ]
                 }
             ]
         })))
@@ -171,14 +198,24 @@ async fn test_get_available_teepods_error() {
 async fn test_get_pubkey_for_config() {
     let mock_server = MockServer::start().await;
 
-    // Mock the pubkey endpoint
+    // Mock the pubkey endpoint with a full PubkeyResponse body
     Mock::given(method("POST"))
         .and(path("/cvms/pubkey/from_cvm_configuration"))
         .and(header("Content-Type", "application/json"))
         .and(header("x-api-key", "test_api_key"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "app_env_encrypt_pubkey": format!("0x{}", hex::encode([1u8; 32])),
-            "app_id_salt": "test_salt"
+            "app_id": "app_1",
+            "app_id_salt": "test_salt",
+            "compose_manifest": { "name": "test", "features": [], "docker_compose_file": "" },
+            "disk_size": 10,
+            "encrypted_env": "",
+            "image": "test:latest",
+            "listed": false,
+            "memory": 1024,
+            "name": "test",
+            "teepod_id": 1,
+            "vcpu": 1
         })))
         .expect(1)
         .mount(&mock_server)

--- a/src/types.rs
+++ b/src/types.rs
@@ -522,3 +522,35 @@ pub struct SystemStatsResponse {
     /// Detailed system information
     pub sysinfo: SystemInfo,
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CVM lifecycle types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Full CVM info from `GET /api/v1/cvms/{cvm_id}`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CvmInfo {
+    pub id: u64,
+    pub status: String,
+    pub name: String,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+/// CVM state from `GET /api/v1/cvms/{cvm_id}/state`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CvmStateResponse {
+    pub status: String,
+    pub is_running: bool,
+}
+
+/// TEE attestation from `GET /api/v1/cvms/{cvm_id}/attestation`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttestationResponse {
+    #[serde(default)]
+    pub tcb_info: serde_json::Value,
+    #[serde(default)]
+    pub app_certificates: serde_json::Value,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}


### PR DESCRIPTION
## Summary

- Add CVM lifecycle methods to TeeClient: `get_cvm`, `get_state`, `start_cvm`, `shutdown_cvm`, `stop_cvm`, `delete_cvm`, `get_attestation`
- Add high-level methods to TeeDeployer: `stop`, `shutdown`, `start`, `delete`, `get_attestation`, `get_status`, `wait_until_running`
- New response types: `CvmInfo`, `CvmStateResponse`, `AttestationResponse`
- Clean up debug prints and verbose eprintln diagnostics
- Fix stale doc examples (deploy_simple_service arg count, method renames)
- Fix pre-existing test failures (incomplete mock response bodies)
- Bump to v0.2.0 with proper crate metadata

## Test plan
- [x] 13 unit tests pass
- [x] 4 doc-tests pass
- [x] `cargo check` clean